### PR TITLE
[BUGFIX] Require ApplicationController

### DIFF
--- a/lib/corneal/generators/app/templates/config/environment.rb
+++ b/lib/corneal/generators/app/templates/config/environment.rb
@@ -8,4 +8,5 @@ ActiveRecord::Base.establish_connection(
   :database => "db/#{ENV['SINATRA_ENV']}.sqlite"
 )
 
+require './app/controllers/application_controller'
 require_all 'app'


### PR DESCRIPTION
Issue #8, handling with Runtime error when a controller that alphabetically comes before 'application_controller.rb' is loaded by server.