### PR TITLE
Remove GitSpecification on database_cleaner gem

### DIFF
--- a/lib/corneal/generators/app/templates/Gemfile
+++ b/lib/corneal/generators/app/templates/Gemfile
@@ -16,5 +16,5 @@ group :test do
   gem 'rspec'
   gem 'capybara'
   gem 'rack-test'
-  gem 'database_cleaner', git: 'https://github.com/bmabey/database_cleaner.git'
+  gem 'database_cleaner'
 end


### PR DESCRIPTION
Fixes #17 

The dependency conflict is resolved by sourcing the 'database_cleaner' gem from rubygems.org instead of the git repository.