### PR TITLE
Remove Ruby environment variable to DRY up code

### DIFF
--- a/lib/corneal/generators/app/templates/Rakefile
+++ b/lib/corneal/generators/app/templates/Rakefile
@@ -1,4 +1,2 @@
-ENV["SINATRA_ENV"] ||= "development"
-
 require_relative './config/environment'
 require 'sinatra/activerecord/rake'


### PR DESCRIPTION
The line `ENV["SINATRA_ENV"] ||= "development"` is at the top of both the `Rakefile` and `environment.rb` file, so I removed it from the `Rakefile` since the very next line in that code requires the `environment.rb` file. The app functions normally without it per my usage.