### PR TITLE
Update to ActiveRecord 5 for higher ruby version compat

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    corneal (1.2.0)
+    corneal (1.3.0)
       activesupport (~> 5.0)
       thor (~> 0.18)
 
@@ -64,7 +64,7 @@ GEM
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
     rake (13.0.1)
-    thor (0.20.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)

--- a/lib/corneal/generators/app/templates/Gemfile
+++ b/lib/corneal/generators/app/templates/Gemfile
@@ -1,11 +1,11 @@
 source 'http://rubygems.org'
 
 gem 'sinatra'
-gem 'activerecord', '~> 4.2', '>= 4.2.6', :require => 'active_record'
+gem 'activerecord', '~> 5.2', :require => 'active_record'
 gem 'sinatra-activerecord', :require => 'sinatra/activerecord'
 gem 'rake'
 gem 'require_all'
-gem 'sqlite3', '~> 1.3.6'
+gem 'sqlite3'
 gem 'thin'
 gem 'shotgun'
 gem 'pry'

--- a/lib/corneal/generators/app/templates/config.ru
+++ b/lib/corneal/generators/app/templates/config.ru
@@ -1,6 +1,6 @@
 require './config/environment'
 
-if ActiveRecord::Migrator.needs_migration?
+if ActiveRecord::Base.connection.migration_context.needs_migration?
   raise 'Migrations are pending. Run `rake db:migrate` to resolve the issue.'
 end
 

--- a/lib/corneal/generators/model/migration.rb.erb
+++ b/lib/corneal/generators/model/migration.rb.erb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < ActiveRecord::Migration[5.2]
   def change
     create_table :<%= table_name %> do |t|
 <% attributes.each do |attribute| -%>

--- a/lib/corneal/version.rb
+++ b/lib/corneal/version.rb
@@ -1,8 +1,8 @@
 module Corneal
   module VERSION
     MAJOR = 1
-    MINOR = 2
-    TINY  = 3
+    MINOR = 3
+    TINY  = 0
 
     STRING = [MAJOR, MINOR, TINY].join('.')
   end


### PR DESCRIPTION
ActiveRecord 4 no longer works with Ruby 2.7.1, but version 6 seems to not work properly with Sinatra and migrations won't run with it, so version 5 seems like a happy medium to stick with for a while.