### PR TITLE
Add bigdecimal gem to template dependencies

### DIFF
--- a/lib/corneal/generators/app/templates/Gemfile
+++ b/lib/corneal/generators/app/templates/Gemfile
@@ -11,6 +11,7 @@ gem 'shotgun'
 gem 'pry'
 gem 'bcrypt'
 gem 'tux'
+gem 'bigdecimal'
 
 group :test do
   gem 'rspec'


### PR DESCRIPTION
Ran into an error while creating a test project: 
`NoMethodError: undefined method `new' for BigDecimal:Class`
and fixed it by adding the dependency.

Potentially this isn't the best way to do this, I'm still learning. 