### PR TITLE
Bring corneal up to date, adds rubocop in dev

### DIFF
--- a/lib/corneal/generators/app/templates/Gemfile
+++ b/lib/corneal/generators/app/templates/Gemfile
@@ -1,11 +1,11 @@
 source 'http://rubygems.org'
 
 gem 'sinatra'
-gem 'activerecord', '~> 4.2', '>= 4.2.6', :require => 'active_record'
+gem 'activerecord', :require => 'active_record'
 gem 'sinatra-activerecord', :require => 'sinatra/activerecord'
 gem 'rake'
 gem 'require_all'
-gem 'sqlite3', '~> 1.3.6'
+gem 'sqlite3', '~> 1.4'
 gem 'thin'
 gem 'shotgun'
 gem 'pry'
@@ -16,5 +16,9 @@ group :test do
   gem 'rspec'
   gem 'capybara'
   gem 'rack-test'
-  gem 'database_cleaner'
+  gem 'database_cleaner', git: 'https://github.com/bmabey/database_cleaner.git'
+end
+
+group :development do
+  gem 'rubocop'
 end

--- a/lib/corneal/generators/app/templates/config.ru
+++ b/lib/corneal/generators/app/templates/config.ru
@@ -1,6 +1,6 @@
 require './config/environment'
 
-if ActiveRecord::Migrator.needs_migration?
+if ActiveRecord::Base.connection.migration_context.needs_migration?
   raise 'Migrations are pending. Run `rake db:migrate` to resolve the issue.'
 end
 


### PR DESCRIPTION
Hey there!

Have been using this a while and decided to PR the changes I usually have to make when generating new projects. The above updates the active record and SQLite versions so the app will run by default when generated. I also added in rubocop in-dev, it's pretty standard to have there at least so should be a good inclusion. 